### PR TITLE
Docker build from GitHub Actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,28 @@
+name: Docker Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    env:
+      IMAGE_NAME: voteagora/tg-crm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          push: false
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Telegram-Attio Integration
 
+[![Docker Build](https://github.com/voteagora/tg-crm/actions/workflows/docker-build.yml/badge.svg)](https://github.com/voteagora/tg-crm/actions/workflows/docker-build.yml)
+
 This service integrates Telegram conversations with Attio CRM, automatically syncing messages as activities in Attio deals.
 
 ## Setup


### PR DESCRIPTION
Build the Docker image using GitHub Actions.

Note that the build takes about 10 minutes. In a follow up we could speed it up drastically by caching layers to the GitHub Container Registry.